### PR TITLE
Header bar for profile page

### DIFF
--- a/src/apps/admin/config/styles.js
+++ b/src/apps/admin/config/styles.js
@@ -60,7 +60,7 @@ export const styles = theme => ({
   },
 
   root: {
-    width: '90%',
+    width: '100%',
     alignSelf: 'center',
   },
   button: {


### PR DESCRIPTION
The header bar for the profile page wasn't spanning the width of the page.