### PR TITLE
Feat: Add Company Links Input Component

### DIFF
--- a/src/apps/admin/components/companylinks.js
+++ b/src/apps/admin/components/companylinks.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Formik, Form, Field, FieldArray } from 'formik';
+import CompanyLinksSelect from './companylinks.select';
+import { TextField } from 'formik-material-ui';
+import styled from 'styled-components';
+import Fab from '@material-ui/core/Fab';
+import AddIcon from '@material-ui/icons/Add';
+import Icon from '@material-ui/core/Icon';
+import DeleteIcon from '@material-ui/icons/Delete';
+import NavigationIcon from '@material-ui/icons/Navigation';
+
+function CompanyLinksInput(props) {
+  const { values, errors, touched, classes } = props;
+  console.log('PROPS IN COMPANY LINKS: ', props);
+
+  return (
+    <FieldArray
+      name="links"
+      render={arrayHelpers => (
+        <div>
+          {values.links && values.links.length > 0 ? (
+            values.links.map((friend, index) => (
+              <Container key={index}>
+                <Field
+                  name={`links.${index}.type`}
+                  component={CompanyLinksSelect}
+                  classes={props.classes}
+                  styles={{
+                    paddingRight: '1rem',
+
+                    minWidth: '150px',
+                  }}
+                />
+                <CodeXTextField
+                  type="text"
+                  name={`links.${index}.payload`}
+                  errors={errors}
+                  touched={touched}
+                  value={values.links[index].payload}
+                  label="Address"
+                  style={{
+                    flexGrow: 2,
+                  }}
+                />
+                <Fab
+                  style={{ marginRight: '1px' }}
+                  size="small"
+                  aria-label="Delete"
+                  className={classes.fab}
+                  onClick={() => arrayHelpers.remove(index)}
+                >
+                  <DeleteIcon />
+                </Fab>
+                {values.links.length === index + 1 ? (
+                  <Fab
+                    onClick={() => arrayHelpers.push('')}
+                    size="small"
+                    color="primary"
+                    aria-label="Add"
+                    className={classes.fab}
+                  >
+                    <AddIcon />
+                  </Fab>
+                ) : null}
+              </Container>
+            ))
+          ) : (
+            <button type="button" onClick={() => arrayHelpers.push('')}>
+              {/* show this when user has removed all friends from the list */}
+              Add a friend
+            </button>
+          )}
+        </div>
+      )}
+    />
+  );
+}
+
+const Container = styled.div`
+  display: flex;
+  margin-top: 1rem;
+`;
+
+export default CompanyLinksInput;
+
+function CodeXTextField({
+  name,
+  type = 'text',
+  label,
+  component = TextField,
+  errors,
+  touched,
+  value,
+  ...rest
+}) {
+  console.log('REST IN CODEX TEXT FIELD', value);
+  const fieldErrors = errors[name];
+  const isTouched = touched[name];
+  return (
+    <>
+      <Field
+        name={name}
+        type={type}
+        label={label || name}
+        component={component}
+        fullWidth={false}
+        InputLabelProps={{}}
+        value={value}
+        {...rest}
+      />
+      {fieldErrors && isTouched ? <div>{fieldErrors}</div> : null}
+    </>
+  );
+}

--- a/src/apps/admin/components/companylinks.select.js
+++ b/src/apps/admin/components/companylinks.select.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Input from '@material-ui/core/Input';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import FilledInput from '@material-ui/core/FilledInput';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import { TextField } from 'formik-material-ui';
+
+const organizationLinkType = [
+  { type: 'UrlPrivacyPolicy', niceName: 'Privacy Policy' },
+  { type: 'UrlSupport', niceName: 'Support' },
+  { type: 'UrlSales', niceName: 'Sales' },
+  { type: 'UrlTermsOfService', niceName: 'TOS' },
+  { type: 'UrlTwitter', niceName: 'Twitter' },
+  { type: 'UrlLinkedIn', niceName: 'LinkedIn' },
+  { type: 'UrlFacebook', niceName: 'Facebook' },
+  { type: 'UrlCrunchbase', niceName: 'Crunchbase' },
+  { type: 'UrlAngellist', niceName: 'Angellist' },
+  { type: 'UrlWebsite', niceName: 'Website' },
+  { type: 'EmailSales', niceName: 'Sales Email' },
+  { type: 'EmailSupport', niceName: 'Support Email' },
+  { type: 'Other', niceName: 'Other' },
+];
+
+export default function SimpleSelect({ classes, field, form, values, styles }) {
+  const inputLabel = React.useRef(null);
+  const [labelWidth, setLabelWidth] = React.useState(0);
+  React.useEffect(() => {
+    setLabelWidth(inputLabel.current.offsetWidth);
+  }, []);
+
+  return (
+    <FormControl className={classes.formControl} style={styles}>
+      <InputLabel ref={inputLabel} htmlFor={field.name}>
+        Link Type
+      </InputLabel>
+      <Select
+        inputProps={field}
+        input={
+          <Input labelWidth={labelWidth} name={field.name} id={field.name} />
+        }
+      >
+        {organizationLinkType.map(item => {
+          return <MenuItem value={item.type}>{item.niceName} </MenuItem>;
+        })}
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/apps/admin/routes/company/index.js
+++ b/src/apps/admin/routes/company/index.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import Downshift from 'downshift';
+import Divider from '@material-ui/core/Divider';
 
 import { Formik, Field, Form } from 'formik';
 import { TextField } from 'formik-material-ui';
@@ -30,6 +31,8 @@ import Fab from '@material-ui/core/Fab';
 import DeleteIcon from '@material-ui/icons/Delete';
 
 import styled from 'styled-components';
+
+import CompanyLinksInput from '../../components/companylinks';
 
 const Transition = React.forwardRef(function Transition(props, ref) {
   return <Slide direction="up" ref={ref} {...props} />;
@@ -64,11 +67,9 @@ export default function CreateCompanyScreen({
   }
 
   const handleCreateCompany = async (
-    { name, description, location, locationjson },
+    { name, description, location, locationjson, links },
     { setSubmitting }
   ) => {
-    console.log('got called');
-    console.log('locationjson', locationjson);
     const { formatted_address, geometry, place_id } = locationjson;
     try {
       const result = await createCompany({
@@ -87,6 +88,15 @@ export default function CreateCompanyScreen({
                 geometry,
                 placeId: place_id,
               },
+            },
+            links: {
+              create: links.map(link => {
+                return {
+                  fromDate: new Date(),
+                  payload: link.payload,
+                  type: link.type,
+                };
+              }),
             },
             affiliation: {
               create: {
@@ -111,7 +121,6 @@ export default function CreateCompanyScreen({
     }
   };
 
-  console.log(rest);
   return (
     <Container className={classes.main}>
       <Dialog open={true} TransitionComponent={Transition} fullWidth={true}>
@@ -131,7 +140,17 @@ function CreateCompanyForm({ classes, handleSubmit, ...rest }) {
     'https://upload.wikimedia.org/wikipedia/commons/2/24/Missing_avatar.svg'
   );
   return (
-    <Formik onSubmit={handleSubmit} initialValues={{}}>
+    <Formik
+      onSubmit={handleSubmit}
+      initialValues={{
+        locationjson: {},
+        links: [
+          { type: 'UrlWebsite', payload: '' },
+          { type: 'UrlTwitter', payload: '' },
+          { type: 'UrlCrunchbase', payload: '' },
+        ],
+      }}
+    >
       {({
         isSubmitting,
         values,
@@ -146,9 +165,21 @@ function CreateCompanyForm({ classes, handleSubmit, ...rest }) {
         return (
           <>
             <FormHeader companyName={name} />
+            <Typography
+              variant="h6"
+              color="primary"
+              style={{
+                fontWeight: '800',
+                marginTop: '1rem',
+                letterSpacing: '-.5px',
+                textDecoration: 'none',
+              }}
+            >
+              Logo
+            </Typography>
             <Form className={classes.form}>
               <div>
-                <div style={{ display: 'flex', justifyContent: 'center' }}>
+                <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
                   <StyledInput
                     onChange={e => {
                       e.stopPropagation();
@@ -170,16 +201,26 @@ function CreateCompanyForm({ classes, handleSubmit, ...rest }) {
                     <Fab
                       style={{
                         margin: 10,
-                        width: 120,
-                        height: 120,
+                        width: 400,
+                        height: 300,
+                        borderRadius: '5px',
                       }}
                     >
                       <label htmlFor="avatar">
                         <Avatar
-                          style={{ width: 120, height: 120 }}
+                          style={{
+                            width: 400,
+                            height: 300,
+                            borderRadius: '5px',
+                          }}
                           src={values.avatar}
                           imgProps={{
-                            style: { maxWidth: '100%', maxHeight: '100%' },
+                            style: {
+                              maxWidth: '100%',
+                              maxHeight: '100%',
+                              width: 400,
+                              height: 300,
+                            },
                           }}
                         />
                       </label>
@@ -188,12 +229,25 @@ function CreateCompanyForm({ classes, handleSubmit, ...rest }) {
                 </div>
               </div>
 
+              <Typography
+                variant="h6"
+                color="primary"
+                style={{
+                  fontWeight: '800',
+                  marginTop: '1rem',
+                  letterSpacing: '-.5px',
+                  textDecoration: 'none',
+                }}
+              >
+                Basics
+              </Typography>
+
               <CodeXTextField
                 name="name"
                 type="text"
                 errors={errors}
                 touched={touched}
-                label="Company Name"
+                label="Name"
                 fullWidth={true}
               />
 
@@ -204,12 +258,33 @@ function CreateCompanyForm({ classes, handleSubmit, ...rest }) {
                 margin="normal"
                 errors={errors}
                 touched={touched}
-                label="Company Description"
+                label="Description"
               />
               <AddressField
                 classes={classes}
                 setFieldValue={setFieldValue}
                 setValues={setValues}
+              />
+              <Typography
+                variant="h6"
+                color="primary"
+                style={{
+                  fontWeight: '800',
+                  marginTop: '1rem',
+                  letterSpacing: '-.5px',
+                  textDecoration: 'none',
+                }}
+              >
+                Company Links
+              </Typography>
+
+              <CompanyLinksInput
+                classes={classes}
+                setFieldValue={setFieldValue}
+                setValues={setValues}
+                errors={errors}
+                touched={touched}
+                values={values}
               />
 
               <SectionWrapper>

--- a/src/apps/admin/routes/company/location.js
+++ b/src/apps/admin/routes/company/location.js
@@ -63,7 +63,9 @@ function GoogleEnhancedAutocomplete({ classes, ...props }) {
     <Downshift
       id="downshift-simple"
       itemToString={itemToString}
-      onChange={selection => props.setValues({ locationjson: selection })}
+      onChange={selection =>
+        props.setFieldValue('locationjson', selection, false)
+      }
     >
       {({
         getInputProps,


### PR DESCRIPTION
This PR adds support for inputting company address/link information. Companies now have the option to add any / as many of the following types of information: 

```
enum OrganizationLinkType {
  UrlPrivacyPolicy
  UrlSupport
  UrlSales
  UrlTermsOfService
  UrlTwitter
  UrlLinkedIn
  UrlFacebook
  UrlCrunchbase
  UrlAngellist
  UrlWebsite
  EmailSales
  EmailSupport
  Other
}
```

<img width="589" alt="Screen Shot 2019-07-02 at 4 59 33 PM" src="https://user-images.githubusercontent.com/14793389/60546177-cd2bf080-9cea-11e9-9d8f-d5dd47f95910.png">
