### PR TITLE
chore: support local dev without code edits

### DIFF
--- a/config/site.js
+++ b/config/site.js
@@ -1,4 +1,10 @@
-require('dotenv').config();
+require('dotenv').config({
+  path: `.env${
+    process.env.NODE_ENV === 'production' || process.env.LOCAL !== 'true'
+      ? '.production'
+      : '.local'
+  }`,
+});
 const theme = require('./theme');
 
 module.exports = () => ({
@@ -16,8 +22,7 @@ module.exports = () => ({
   },
   api: {
     graphql: {
-      endpoint: 'http://35.239.56.1/apollo',
-      // endpoint: 'http://localhost:4000',
+      endpoint: process.env.GATSBY_GRAPHQL_ENDPOINT,
       typeName: 'TechList',
       fieldName: 'allTechList',
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -43,6 +43,15 @@ module.exports = {
         createLink: pluginOptions => {
           return new Promise((res, rej) => {
             jwt.then(token => {
+              console.log(
+                `\n****************************************************`
+              );
+              console.log(
+                `Connecting to => ${process.env.GATSBY_GRAPHQL_ENDPOINT}`
+              );
+              console.log(
+                `****************************************************\n`
+              );
               const client = createHttpLink({
                 uri: config.api.graphql.endpoint,
                 headers: {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,7 +5,13 @@
  */
 
 // You can delete this file if you're not using it
-require('dotenv').config();
+require('dotenv').config({
+  path: `.env${
+    process.env.NODE_ENV === 'production' || process.env.LOCAL !== true
+      ? '.production'
+      : '.local'
+  }`,
+});
 const path = require('path');
 const slugify = require('slugify');
 const crypto = require('crypto');
@@ -134,7 +140,7 @@ exports.sourceNodes = async ({
       `https://api.cognitive.microsoft.com/bing/v7.0/news/search?q=legal+tech&freshness=Week&count=20&mkt=en-US`,
       {
         headers: {
-          'Ocp-Apim-Subscription-Key': process.env.BING_API_KEY,
+          'Ocp-Apim-Subscription-Key': process.env.GATSBY_BING_API_KEY,
         },
       }
     )

--- a/src/html.js
+++ b/src/html.js
@@ -27,7 +27,7 @@ export default function HTML(props) {
 
         <script
           src={`https://maps.googleapis.com/maps/api/js?key=${
-            process.env.GOOGLE_MAPS_API_KEY
+            process.env.GATSBY_GOOGLE_MAPS_API_KEY
           }&libraries=geometry,drawing,places`}
           async
           defer

--- a/src/store/apollo.js
+++ b/src/store/apollo.js
@@ -1,5 +1,4 @@
 import fetch from 'node-fetch';
-
 import { ApolloClient } from 'apollo-client';
 import { ApolloLink } from 'apollo-link';
 import { onError } from 'apollo-link-error';
@@ -19,14 +18,13 @@ const clientCache = new InMemoryCache({
 const httpLink = process.browser
   ? createPersistedQueryLink().concat(
       new BatchHttpLink({
-        uri: 'http://35.239.56.1/apollo',
-        // uri: 'http://localhost:4000',
+        uri: process.env.GATSBY_GRAPHQL_ENDPOINT,
         fetch: fetch,
       })
     )
   : createPersistedQueryLink().concat(
       new BatchHttpLink({
-        uri: 'http://35.239.56.1/apollo',
+        uri: process.env.GATSBY_GRAPHQL_ENDPOINT,
         // uri: 'http://localhost:4000',
         fetch: fetch,
       })
@@ -37,9 +35,7 @@ const asyncAuthLink = setContext(
     new Promise((success, fail) => {
       const user = getUser()
         .then(user => {
-          console.log('USER IN SET CONTEXT', user);
           const token = getToken();
-          console.log('token', token);
           success({
             headers: {
               ...headers,
@@ -74,10 +70,7 @@ export function configureApolloClient() {
     cache: clientCache,
     connectToDevTools: true,
     ssrMode: true,
-    name:
-      process.env.NODE_ENV === 'production'
-        ? 'react-client-prod'
-        : 'react-client-dev',
-    version: process.env.NODE_ENV === 'production' ? '0.0.0-prod' : '0.0.0-dev',
+    name: process.env.GATSBY_APPLICATION_NAME,
+    version: process.env.GATSBY_APPLICATION_VERSION,
   });
 }

--- a/src/store/utils/auth-client.js
+++ b/src/store/utils/auth-client.js
@@ -49,7 +49,7 @@ async function getUser() {
     console.log('NO TOKEN');
     return Promise.resolve(null);
   }
-  const client = new GraphQLClient('http://35.239.56.1/apollo', {
+  const client = new GraphQLClient(process.env.GATSBY_GRAPHQL_ENDPOINT, {
     headers: {
       Authorization: `Bearer ${token}`,
     },

--- a/src/templates/company/news.js
+++ b/src/templates/company/news.js
@@ -14,11 +14,14 @@ export function CompanyNews({ classes, company, ...props }) {
   const qstring = company.name[0].payload;
 
   useEffect(() => {
-    fetch(`${process.env.BING_SEARCH_NEWS_API}?q=${encodeURI(qstring)}`, {
-      headers: {
-        'Ocp-Apim-Subscription-Key': process.env.BING_API_KEY,
-      },
-    })
+    fetch(
+      `${process.env.GATSBY_BING_SEARCH_NEWS_API}?q=${encodeURI(qstring)}`,
+      {
+        headers: {
+          'Ocp-Apim-Subscription-Key': process.env.GATSBY_BING_API_KEY,
+        },
+      }
+    )
       .then(data => data.json())
       .then(data => {
         if (data && data.value && data.value.length > 0) {


### PR DESCRIPTION
Sometimes it's necessary to run one's development environment against localhost rather than the cloud. Prior to this pull request, doing so required editing at least three files to change hardcoded endpoint values (and then remembering to change them back before commit/push time). This pull request parameterizes environment selection by adopting the following api: 

To run in development mode against localhost, use the following command: 
`LOCAL=true yarn develop` 

To run in development mode against the cloud, use the following command: 
`yarn develop`

The endpoint against which one is using will be displayed prominently in the console: 

<img width="473" alt="Screen Shot 2019-07-09 at 9 09 08 AM" src="https://user-images.githubusercontent.com/14793389/60890441-4cf51600-a229-11e9-8824-8029877fc883.png">
