### PR TITLE
fix: Restyle logo in create company

### DIFF
--- a/src/apps/admin/components/select/helpers/renderSuggestions.js
+++ b/src/apps/admin/components/select/helpers/renderSuggestions.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import MenuItem from '@material-ui/core/MenuItem';
 import PropTypes from 'prop-types';
+import MenuItem from '@material-ui/core/MenuItem';
 
 export function renderSuggestion(suggestionProps) {
   const {

--- a/src/apps/admin/features/company.create/components/logo.js
+++ b/src/apps/admin/features/company.create/components/logo.js
@@ -38,15 +38,16 @@ export function Logo({
             <label htmlFor="avatar">
               <Avatar
                 style={{
-                  width: '100%',
-                  height: '100%',
+                  minWidth: 250,
+                  minHeight: 200,
                   borderRadius: '5px',
+                  padding: 10,
                 }}
                 src={values.logo}
                 imgProps={{
                   style: {
-                    maxWidth: '100%',
-                    maxHeight: '100%',
+                    height: '100%',
+                    objectFit: 'contain',
                   },
                 }}
               />
@@ -65,32 +66,19 @@ const InputContainer = styled.div`
 
 const InputWrapper = styled(InputContainer)`
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
 `;
 
 const InputLabel = styled.label`
   display: flex;
   justify-content: center;
-  min-width: 99%;
+  min-width: 250px;
 `;
 
 const StyledFab = styled(Fab)`
-  margin: 10px;
-  min-width: 50%;
-  max-width: 50%;
-  max-height: 200px;
+  min-width: 250px;
   min-height: 200px;
   border-radius: 5px;
-
-  @media (max-width: 620px) {
-    max-height: 175px;
-    min-height: 175px;
-  }
-
-  @media (max-width: 560px) {
-    max-height: 150px;
-    min-height: 150px;
-  }
 `;
 
 const StyledInput = styled.input.attrs({

--- a/src/apps/admin/features/company.create/helpers/renderExpansionPanel.js
+++ b/src/apps/admin/features/company.create/helpers/renderExpansionPanel.js
@@ -15,10 +15,13 @@ export function CodeXExpansionPanel({
   titleStyle,
   titleVariant,
   error,
+  style,
   ...props
 }) {
   return (
-    <ExpansionPanel style={error ? { border: '1px solid red' } : {}}>
+    <ExpansionPanel
+      style={error ? { border: '1px solid red', ...style } : style}
+    >
       <ExpansionPanelSummary expandIcon={expandIcon}>
         <Typography
           variant={titleVariant}

--- a/src/apps/admin/features/company.create/index.js
+++ b/src/apps/admin/features/company.create/index.js
@@ -127,6 +127,7 @@ export function CreateCompany({ handleCompanyCreate, classes, ...props }) {
               <CodeXExpansionPanel
                 title="Logo"
                 error={errors.logo && touched.logo ? true : false}
+                style={{ maxHeight: 308 }}
               >
                 <Logo {...getProps} />
               </CodeXExpansionPanel>


### PR DESCRIPTION
Restyled logo input, images are now confined to the space available, fab now opens file picker and file picker can not be opened from clicking outside fab