### PR TITLE
fix: Resize logo in preview

### DIFF
--- a/src/apps/admin/features/company.create/components/preview.js
+++ b/src/apps/admin/features/company.create/components/preview.js
@@ -24,8 +24,10 @@ const useStyles = makeStyles(theme => ({
     maxWidth: 212,
   },
   cover: {
-    width: 151,
-    height: 151,
+    minWidth: 151,
+    maxWidth: 151,
+    minHeight: 151,
+    maxHeight: 151,
   },
   controls: {
     display: 'flex',


### PR DESCRIPTION
Logo was getting pushed around, stretched, and squashed. Gave it min/max height/width now it is consistent