### PR TITLE
fix: Make line height of description text smaller

### DIFF
--- a/src/apps/admin/features/company.create/components/preview.js
+++ b/src/apps/admin/features/company.create/components/preview.js
@@ -80,6 +80,7 @@ export function CompanyCreatePreview({ values }) {
             style={{
               letterSpacing: '-.5px',
               textDecoration: 'none',
+              lineHeight: 1.35,
             }}
           >
             {values.description}


### PR DESCRIPTION
Description text's line height was too big, it was 1.75 now it is 1.35

#111