### PR TITLE
add several sizes at different break points

### DIFF
--- a/src/apps/admin/routes/company/index.js
+++ b/src/apps/admin/routes/company/index.js
@@ -47,6 +47,15 @@ const StyledDialogContent = styled(DialogContent)`
     padding: 10px;
     max-height: 100vh;
   }
+  @media (min-width: 1000px) {
+    width: 800px;
+  }
+  @media (min-width: 1200px) {
+    width: 1000px;
+  }
+  @media (min-width: 1600px) {
+    width: 1400px;
+  }
 `;
 
 const PaperComponent = ({ children, ...props }) => {


### PR DESCRIPTION
I'm not sure if this is the best way to do this but it works. If I open the modal with with the browser at full width it's 1400px across and then as you resize the window down it gets smaller. Still looks fine on mobile.

Closes #118 